### PR TITLE
Support allowing traffic in on an entire interface

### DIFF
--- a/_states/ufw.py
+++ b/_states/ufw.py
@@ -27,10 +27,14 @@ def _resolve(host):
     return socket.gethostbyname(host)
 
 
-def _as_rule(method, app, protocol, from_addr, from_port, to_addr, to_port):
+def _as_rule(method, app, interface, protocol, from_addr, from_port, to_addr, to_port):
     cmd = [method]
     if app is not None:
         cmd.append(app)
+    elif interface is not None:
+    	cmd.append("in")
+    	cmd.append("on")
+    	cmd.append(interface)
     else:
         if protocol is not None:
             cmd.append("proto")
@@ -74,10 +78,10 @@ def enabled(name, **kwargs):
     return _changed(name, "UFW is enabled", enabled=True)
 
 
-def allowed(name, app=None, protocol=None,
+def allowed(name, app=None, interface=None, protocol=None,
             from_addr=None, from_port=None, to_addr=None, to_port=None):
 
-    rule = _as_rule("allow", app=app, protocol=protocol,
+    rule = _as_rule("allow", app=app, interface=None, protocol=protocol,
                    from_addr=from_addr, from_port=from_port, to_addr=to_addr, to_port=to_port)
 
     if __opts__['test']:

--- a/_states/ufw.py
+++ b/_states/ufw.py
@@ -81,7 +81,7 @@ def enabled(name, **kwargs):
 def allowed(name, app=None, interface=None, protocol=None,
             from_addr=None, from_port=None, to_addr=None, to_port=None):
 
-    rule = _as_rule("allow", app=app, interface=None, protocol=protocol,
+    rule = _as_rule("allow", app=app, interface=interface, protocol=protocol,
                    from_addr=from_addr, from_port=from_port, to_addr=to_addr, to_port=to_port)
 
     if __opts__['test']:

--- a/pillar.example
+++ b/pillar.example
@@ -37,3 +37,7 @@ ufw:
   # Allow an application defined at /etc/ufw/applications.d/
   applications:
     - OpenSSH
+
+  # Allow all traffic in on the specified interface
+  interfaces:
+    - eth1

--- a/ufw/init.sls
+++ b/ufw/init.sls
@@ -50,6 +50,17 @@ ufw-app-{{app_name}}:
       - pkg: ufw
 
   {%- endfor %}
+  
+  # Interfaces
+  {%- for interface in ufw.get('interfaces', []) %}
+
+ufw-interface-{{interface}}:
+  ufw.allowed:
+    - interface: {{interface}}
+    - require:
+      - pkg: ufw
+
+  {%- endfor %}
 
 {% else %}
   #ufw:


### PR DESCRIPTION
Specifying interface: parameter works like the app parameter now, and calls "allow in on {interface}"
