### PR TITLE
Fix regex parse to actually match pure IPv4 or IPv6 with optional netmask

### DIFF
--- a/_states/ufw.py
+++ b/_states/ufw.py
@@ -20,9 +20,13 @@ def _changed(name, msg, **changes):
 
 
 def _resolve(host):
-    # pure IP address / netmask IPv4 or IPv6 ?
-    if re.match(r'^([0-9\.](::))+(/[0-9]+)?$', host):
-        return
+    # pure IP address / netmask IPv4?
+    if re.match(r'^([0-9\.])+(/[0-9]+)?$', host):
+        return host
+
+    # pure IPv6 address / netmask?
+    if re.match(r'^([0-9a-f:]+)(/[0-9]+)?$', host):
+        return host
 
     return socket.gethostbyname(host)
 

--- a/ufw/init.sls
+++ b/ufw/init.sls
@@ -24,13 +24,13 @@ ufw-svc-{{service_name}}-{{from_addr}}:
   ufw.allowed:
     - protocol: {{protocol}}
     {%- if from_addr != None %}
-    - from_addr: {{from_addr}}
+    - from_addr: "{{from_addr}}"
     {%- endif %}
     {%- if from_port != None %}
     - from_port: "{{from_port}}"
     {%- endif %}
     {%- if to_addr != None %}
-    - to_addr: {{to_addr}}
+    - to_addr: "{{to_addr}}"
     {%- endif %}
     - to_port: "{{service_name}}"
     - require:


### PR DESCRIPTION
The current match and return didn't actually match any real values and returned nothing, which resulted in an invalid cmd.

Split the matcher into one for IPv4 (with optional netmask) and one for IPv6 (with optional netmask). And fixed the return value.

Now you can actually add IPv6 to your pillar and it works.